### PR TITLE
refactor: replace hardcoded localhost with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+HEALTH_CHECK_URL=http://localhost:3000/health
+BASE_URL=http://localhost
+PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENTRYPOINT ["node", "./dist/index.js"]
 # Metadata
 LABEL description="MCP Server for Outlook Calendar with SSE support"
 
-# Health check (adjust the health check command as needed)
+# Health check using environment variable for host
+ENV HEALTH_CHECK_URL=http://localhost:3000/health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider $HEALTH_CHECK_URL || exit 1

--- a/src/server/sseServer.ts
+++ b/src/server/sseServer.ts
@@ -174,9 +174,10 @@ export class SseServer {
       });
 
       this.server.listen(this.port, () => {
-        console.log(`SSE Server running on http://localhost:${this.port}`);
-        console.log(`SSE endpoint: http://localhost:${this.port}/events`);
-        console.log(`Calendar API endpoint: http://localhost:${this.port}/api/calendar/events`);
+        const baseUrl = process.env.BASE_URL || `http://localhost:${this.port}`;
+        console.log(`SSE Server running on ${baseUrl}`);
+        console.log(`SSE endpoint: ${baseUrl}/events`);
+        console.log(`Calendar API endpoint: ${baseUrl}/api/calendar/events`);
         resolve();
       });
     });


### PR DESCRIPTION
## Changes Made

- Updated Dockerfile to use HEALTH_CHECK_URL environment variable
- Modified sseServer.ts to use BASE_URL environment variable with fallback to localhost
- Added environment variables to .env.example for documentation

## Testing

- [ ] Verify server starts correctly with default values
- [ ] Test with custom BASE_URL and HEALTH_CHECK_URL environment variables
- [ ] Confirm health check endpoint works as expected